### PR TITLE
Fix: saleCompleted() blocked by CCA rounding dust

### DIFF
--- a/src/CCADisbursementTracker.sol
+++ b/src/CCADisbursementTracker.sol
@@ -124,10 +124,17 @@ contract CCADisbursementTracker is ERC20 {
         revert TokenIsUntransferable();
     }
 
-    /// @notice Returns true when the sale is complete (total supply is zero).
+    /// @notice Maximum residual dust (in wei) tolerated when checking sale completion.
+    /// @dev The CCA clearing math can leave a small rounding residual in its token balance that no
+    ///      function can extract. This threshold allows saleCompleted() to return true despite that dust.
+    uint256 public constant DUST_THRESHOLD = 1e6;
+
+    /// @notice Returns true when the sale is complete (total supply at or below dust threshold).
     /// @dev Expects sweepUnsoldTokens to have been called and all bid tokens claimed via claimTokens/claimTokensBatch.
+    ///      Uses a dust threshold instead of strict zero check because the CCA's clearing math can leave
+    ///      a small wei-level residual in its balance that is impossible to extract.
     function saleCompleted() public view returns (bool) {
-        return totalSupply() == 0;
+        return totalSupply() <= DUST_THRESHOLD;
     }
 
     /// @dev Sum of all unrecorded disbursements across all accounts.


### PR DESCRIPTION
## Problem

After a successful CCA auction where all bids are claimed (`claimTokens`) and unsold tokens are swept (`sweepUnsoldTokens`), the tracker's `totalSupply()` returns 1 wei instead of 0.

This happens because the CCA's clearing math leaves a small rounding residual (1 wei observed) in its token balance. No function on the CCA exists to extract this dust.

Since `saleCompleted()` checks `totalSupply() == 0`, it can never return `true`, which means `recordDisbursements()` permanently reverts with `SaleNotCompleted`. The disburser cannot record any disbursements, blocking the entire on-chain bookkeeping flow.

## Reproduction (Sepolia)

| Contract | Address |
|----------|---------|
| Tracker | `0x35b0bC5e964281bb46647415E39958369A55f26a` |
| CCA | `0x3D5b3FB24f0c8B1c582caB35F55901788C03619b` |

Steps:
1. Deploy CCA + Tracker (1,000,000 tokens, ~0.01 ETH raised, auction graduated)
2. Place bid, wait for auction to end
3. Call `claimTokens` — tokens burned, IOU recorded
4. Call `sweepUnsoldTokens` — remaining tokens burned, IOU recorded
5. `tracker.totalSupply()` → **1 wei** (not 0)
6. `tracker.saleCompleted()` → **false**
7. `tracker.recordDisbursements(...)` → **reverts with `SaleNotCompleted`**

## Fix

Replace the strict equality check in `saleCompleted()` with a dust-tolerant threshold:

```diff
+ uint256 public constant DUST_THRESHOLD = 1e6;
+
  function saleCompleted() public view returns (bool) {
-     return totalSupply() == 0;
+     return totalSupply() <= DUST_THRESHOLD;
  }
```

The threshold of 1e6 wei is negligible relative to any realistic token supply and safely covers the CCA's rounding behavior.